### PR TITLE
Works for Kong 2.x versions

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -1,7 +1,8 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
+--local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
+local responses = kong.response
 
 local ngx_error = ngx.ERR
 local ngx_debug = ngx.DEBUG
@@ -114,7 +115,10 @@ function JWTAuthHandler:access(conf)
   if not token then
     ngx_log(ngx_error, "[jwt-auth plugin] Cannot get JWT token, add the ",
                        "JWT plugin to be able to use the JWT-Auth plugin")
-    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    return kong.response.exit(403, {
+                        message = "You cannot consume this service"
+                      })
+    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
   -- decode token to get roles claim
@@ -129,7 +133,10 @@ function JWTAuthHandler:access(conf)
 
   -- check if no roles claimed..
   if not roles then
-    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    return kong.response.exit(403, {
+                        message = "You cannot consume this service"
+                      })
+    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
   -- if the claim is a string (single role), make it a table
@@ -143,11 +150,17 @@ function JWTAuthHandler:access(conf)
   end
 
   if conf.policy == policy_ANY and not role_in_roles_claim(conf.roles, roles) then
-    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    return kong.response.exit(403, {
+                        message = "You cannot consume this service"
+                      })
   end
 
   if conf.policy == policy_ALL and not all_roles_in_roles_claim(conf.roles, roles) then
-    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    return kong.response.exit(403, {
+                        message = "You cannot consume this service"
+                      })
   end
 
 end


### PR DESCRIPTION
Deprecated --> responses.send_HTTP_FORBIDDEN and local responses = require "kong.tools.responses"